### PR TITLE
Add Status Check for Registry and Bundling Endpoints

### DIFF
--- a/scripts/run-checks-and-write-log.ts
+++ b/scripts/run-checks-and-write-log.ts
@@ -2,6 +2,7 @@ import { checkRegistryHealth } from "../status-checks/check-registry-health"
 import { checkAutoroutingApiHealth } from "../status-checks/check-autorouting-api-health"
 import { checkFreeroutingClusterHealth } from "../status-checks/check-freerouting-cluster-health"
 import { checkJLCSearchHealth } from "../status-checks/check-jlcsearch-health"
+import { checkRegistryAndBundlingHealth } from "../status-checks/check-registry-and-bundling-health"
 import fs from "node:fs"
 
 interface StatusCheck {
@@ -19,9 +20,10 @@ async function runChecksAndWriteLog() {
     { name: "autorouting-api", fn: checkAutoroutingApiHealth },
     { name: "freerouting-cluster", fn: checkFreeroutingClusterHealth },
     { name: "jlcsearch-api", fn: checkJLCSearchHealth },
+    { name: "registry and bundling", fn: checkRegistryAndBundlingHealth },
   ]
 
-  const results = await Promise.all(
+  const results: StatusCheck["checks"] = await Promise.all(
     checks.map(async (check) => {
       const result = await check.fn()
       if (!result.ok) {
@@ -57,6 +59,7 @@ async function runChecksAndWriteLog() {
 
   await Bun.write(
     "./statuses.jsonl",
+    // biome-ignore lint/style/useTemplate: <explanation>
     recentLogs.map((log) => JSON.stringify(log)).join("\n") + "\n",
   )
 }

--- a/status-checks/check-registry-and-bundling-health.ts
+++ b/status-checks/check-registry-and-bundling-health.ts
@@ -1,0 +1,32 @@
+import type { HealthCheckFunction } from "./types";
+import ky from "ky";
+
+const EXAMPLE_PACKAGE = "seveibar/usb-c-flashlight";
+const ENDPOINTS = [
+  `https://esm.tscircuit.com/${EXAMPLE_PACKAGE}`,
+  `https://cjs.tscircuit.com/${EXAMPLE_PACKAGE}`,
+  `https://npm.tscircuit.com/${encodeURIComponent(EXAMPLE_PACKAGE)}`,
+];
+
+export const checkRegistryAndBundlingHealth: HealthCheckFunction = async () => {
+  try {
+    const randomParam = Math.random().toString(36).substring(7);
+
+    await Promise.all(
+      ENDPOINTS.map((url) =>
+        ky.get(`${url}?cachebust=${randomParam}`, {
+          timeout: 5000,
+        })
+      )
+    );
+
+    return { ok: true };
+  } catch (err) {
+    return {
+      ok: false,
+      error: {
+        message: "Registry and Bundling Health Check Failed",
+      },
+    };
+  }
+};


### PR DESCRIPTION
/claim #9
This PR introduces a status check for the "registry and bundling" endpoints, ensuring the health of the following services:  

- `esm.tscircuit.com`  
- `cjs.tscircuit.com`  
- `npm.tscircuit.com`  

The status check polls the following endpoints:  
- `https://esm.tscircuit.com/seveibar/usb-c-flashlight`  
- `https://cjs.tscircuit.com/seveibar/usb-c-flashlight`  
- `https://npm.tscircuit.com/seveibar%2Fusb-c-flashlight`  
