### PR TITLE
Improved the outage table for mobile responsiveness

### DIFF
--- a/components/OutageTable.tsx
+++ b/components/OutageTable.tsx
@@ -23,11 +23,17 @@ export const OutageTable = ({
         <table className="min-w-full">
           <thead>
             <tr className="border-b">
-              <th className="text-left py-2">Service</th>
-              <th className="text-left py-2">Start Time</th>
-              <th className="text-left py-2">End Time</th>
-              <th className="text-left py-2">Duration</th>
-              <th className="text-left py-2">Status</th>
+              <th className="text-left py-2 px-4 whitespace-nowrap">Service</th>
+              <th className="text-left py-2 px-4 whitespace-nowrap">
+                Start Time
+              </th>
+              <th className="text-left py-2 px-4 whitespace-nowrap">
+                End Time
+              </th>
+              <th className="text-left py-2 px-4 whitespace-nowrap">
+                Duration
+              </th>
+              <th className="text-left py-2 px-4 whitespace-nowrap">Status</th>
             </tr>
           </thead>
           <tbody>
@@ -37,11 +43,19 @@ export const OutageTable = ({
               .map((outage, i) => (
                 // biome-ignore lint/suspicious/noArrayIndexKey: <explanation>
                 <tr key={i} className="border-b">
-                  <td className="py-2">{outage.service}</td>
-                  <td className="py-2">{outage.start.toLocaleString()}</td>
-                  <td className="py-2">{outage.end.toLocaleString()}</td>
-                  <td className="py-2">{formatDuration(outage.duration)}</td>
-                  <td className="py-2">
+                  <td className="py-2 px-4 whitespace-nowrap">
+                    {outage.service}
+                  </td>
+                  <td className="py-2 px-4 whitespace-nowrap">
+                    {outage.start.toLocaleString()}
+                  </td>
+                  <td className="py-2 px-4 whitespace-nowrap">
+                    {outage.end.toLocaleString()}
+                  </td>
+                  <td className="py-2 px-4 whitespace-nowrap">
+                    {formatDuration(outage.duration)}
+                  </td>
+                  <td className="py-2 px-4 whitespace-nowrap">
                     <span
                       className={`px-2 py-1 rounded text-sm ${outage.isOngoing ? "bg-red-100 text-red-800" : "bg-gray-100"}`}
                     >


### PR DESCRIPTION
Before:
![image](https://github.com/user-attachments/assets/d1c40375-e120-4dca-af68-0afa0e55cf07)


After:
![image](https://github.com/user-attachments/assets/9a284196-45d9-43c7-bce3-7f586e73ddc5)

![image](https://github.com/user-attachments/assets/68c64ea0-823d-40c7-9de5-8197e076a5c9)
