### PR TITLE
Increase status check interval to 30 minutes

### DIFF
--- a/.github/workflows/status-checks.yml
+++ b/.github/workflows/status-checks.yml
@@ -2,7 +2,7 @@ name: Status Checks
 
 on:
   schedule:
-    - cron: '*/10 * * * *'  # Run every 10 minutes
+    - cron: '*/30 * * * *'  # Run every 30 minutes
   workflow_dispatch:  # Allow manual triggers
 
 jobs:


### PR DESCRIPTION
## Summary
- slow status check cron to every 30 minutes instead of every 10

## Testing
- `bun run format:check`
- `bun run typecheck`


------
https://chatgpt.com/codex/tasks/task_b_689d7713bf808327ba1387667bdbd599