### PR TITLE
feat: add full-circuit-render status check (#13)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -1,5 +1,6 @@
 {
   "lockfileVersion": 1,
+  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "status",

--- a/scripts/run-checks-and-write-log.ts
+++ b/scripts/run-checks-and-write-log.ts
@@ -1,13 +1,14 @@
-import { checkRegistryHealth } from "../status-checks/check-registry-health"
+import fs from "node:fs"
+import { checkCompileApiHealth } from "status-checks/check-compile-api-health"
+import { checkFlyRegistryHealth } from "status-checks/check-fly-registry-health"
 import { checkAutoroutingApiHealth } from "../status-checks/check-autorouting-api-health"
+import { checkBrowserPreviewHealth } from "../status-checks/check-browser-preview-health"
 import { checkFreeroutingClusterHealth } from "../status-checks/check-freerouting-cluster-health"
+import { checkFullCircuitRenderHealth } from "../status-checks/check-full-circuit-render-health"
 import { checkJLCSearchHealth } from "../status-checks/check-jlcsearch-health"
 import { checkRegistryAndBundlingHealth } from "../status-checks/check-registry-and-bundling-health"
-import fs from "node:fs"
-import { checkFlyRegistryHealth } from "status-checks/check-fly-registry-health"
-import { checkCompileApiHealth } from "status-checks/check-compile-api-health"
+import { checkRegistryHealth } from "../status-checks/check-registry-health"
 import { checkSvgServiceHealth } from "../status-checks/check-svg-service-health"
-import { checkBrowserPreviewHealth } from "../status-checks/check-browser-preview-health"
 import { checkTscircuitPackageHealth } from "../status-checks/check-tscircuit-package-health"
 import { checkUsercodeHealth } from "../status-checks/check-usercode-health"
 
@@ -34,6 +35,7 @@ async function runChecksAndWriteLog() {
     { name: "browser_preview", fn: checkBrowserPreviewHealth },
     { name: "tscircuit_package", fn: checkTscircuitPackageHealth },
     { name: "usercode_api", fn: checkUsercodeHealth },
+    { name: "full_circuit_render", fn: checkFullCircuitRenderHealth },
   ]
 
   const results: StatusCheck["checks"] = await Promise.all(

--- a/status-checks/check-full-circuit-render-health.ts
+++ b/status-checks/check-full-circuit-render-health.ts
@@ -1,0 +1,114 @@
+import ky from "ky"
+import exampleUnroutedCircuit from "../assets/example-unrouted-circuit.json"
+import type { HealthCheckFunction } from "./types"
+
+/**
+ * "Full Circuit Test Check" (issue #13): render a full circuit end-to-end,
+ * exercising autorouting AND svg rendering of the routed result — closer to
+ * what a user experiences than the individual service pings.
+ */
+export const checkFullCircuitRenderHealth: HealthCheckFunction = async () => {
+  try {
+    // 1. Route the example circuit through the autorouting API
+    const createJobRes = await ky
+      .post("https://registry-api.tscircuit.com/autorouting/jobs/create", {
+        json: {
+          input_circuit_json: exampleUnroutedCircuit,
+          provider: "freerouting",
+          autostart: true,
+          display_name: "full_circuit_render_health_check",
+        },
+      })
+      .json<{ autorouting_job: { autorouting_job_id: string } }>()
+
+    const jobId = createJobRes.autorouting_job.autorouting_job_id
+
+    const startTime = Date.now()
+    const TIMEOUT = 45000
+
+    let routedCircuitJson: unknown[] | null = null
+    while (Date.now() - startTime < TIMEOUT) {
+      const { autorouting_job: job } = await ky
+        .post("https://registry-api.tscircuit.com/autorouting/jobs/get", {
+          json: { autorouting_job_id: jobId },
+        })
+        .json<{
+          autorouting_job: {
+            is_finished: boolean
+            has_error: boolean
+            error?: unknown
+          }
+        }>()
+
+      if (job.has_error) {
+        return {
+          ok: false,
+          error: {
+            message: `Full circuit render: autorouting failed: ${JSON.stringify(job.error)}`,
+          },
+        }
+      }
+
+      if (job.is_finished) {
+        const outputRes = await ky
+          .post(
+            "https://registry-api.tscircuit.com/autorouting/jobs/get_output",
+            {
+              json: { autorouting_job_id: jobId },
+            },
+          )
+          .json<{ autorouting_job_output: { output_pcb_traces: unknown[] } }>()
+        const traces = outputRes.autorouting_job_output.output_pcb_traces
+        if (!Array.isArray(traces) || traces.length === 0) {
+          return {
+            ok: false,
+            error: {
+              message: "Full circuit render: autorouting returned no traces",
+            },
+          }
+        }
+        routedCircuitJson = [
+          ...(exampleUnroutedCircuit as unknown[]),
+          ...traces,
+        ]
+        break
+      }
+
+      await new Promise((resolve) => setTimeout(resolve, 1000))
+    }
+
+    if (!routedCircuitJson) {
+      return {
+        ok: false,
+        error: { message: "Full circuit render: autorouting timed out" },
+      }
+    }
+
+    // 2. Render the routed circuit through the svg service
+    const svg = await ky
+      .post("https://svg.tscircuit.com/", {
+        searchParams: { svg_type: "pcb" },
+        json: { circuit_json: routedCircuitJson },
+        timeout: 15000,
+      })
+      .text()
+
+    if (!svg.includes("<svg")) {
+      return {
+        ok: false,
+        error: {
+          message: "Full circuit render: svg service returned no <svg output",
+        },
+      }
+    }
+
+    return { ok: true }
+  } catch (err) {
+    return {
+      ok: false,
+      error: {
+        message: `Full circuit render health check failed: ${err instanceof Error ? err.message : String(err)}`,
+      },
+    }
+  }
+}


### PR DESCRIPTION
Closes #13 ("Full Circuit Test Check").

## What

Adds a `full_circuit_render` status check that exercises the **full user-facing render path** instead of individual service pings:

1. Routes `assets/example-unrouted-circuit.json` through the autorouting API (same flow as `check-autorouting-api-health`)
2. Verifies traces actually come back (`output_pcb_traces` non-empty)
3. Renders the routed circuit through the svg service (`POST svg.tscircuit.com?svg_type=pcb` with `{circuit_json}`)
4. Verifies real `<svg` output

Each failure mode returns a distinct message (autorouting failed / no traces / timed out / no svg output), so an outage is attributable to a stage at a glance.

## Verification

- Ran the check against production: `{"ok":true}` end-to-end
- `bunx tsc --noEmit` / `biome check` — clean
- Wired into `run-checks-and-write-log.ts` following the existing pattern
